### PR TITLE
Long argument for -p

### DIFF
--- a/src/read_seeding.c
+++ b/src/read_seeding.c
@@ -1498,7 +1498,7 @@ static struct option long_option[] = {
 	{"max-intron-len", required_argument, NULL, 'I'},
 	{"zdrop", required_argument, NULL, 'z'},
     {"noncan", required_argument, NULL, 'R'},
-	{"secondary-to-primary", required_argument, NULL, 'p'},
+	{"secondary-ratio", required_argument, NULL, 'p'},
 	{"e-shift", required_argument, NULL, 'e'},
 	{"temp-file-perfix", required_argument, NULL, 'f'},
 	{"without-qual", no_argument, NULL, 'Q'},


### PR DESCRIPTION
The long argument for `-p` states `--secondary-ratio` in the help and README but the parser looks for `primary-to-secondary`. This causes `unrecognized option '--secondary-ratio'` error.